### PR TITLE
fft_eval: non-Linux builds tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,20 @@ matrix:
     - os: linux
       script:
       - make CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y clean && make CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y test
+    # windows cross-compiler
+    - os: linux
+      env:
+      - MXE_CPU=i686
+      - PATH="/usr/lib/mxe/usr/bin/:$PATH"
+      - MAKE_FLAGS="CROSS=${MXE_CPU}-w64-mingw32.static- V=s"
+      addons:
+        apt:
+          sources:
+          - sourceline: 'deb http://pkg.mxe.cc/repos/apt/ xenial main'
+            key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC6BF758A33A3A276'
+          packages:
+          - mxe-i686-w64-mingw32.static-gcc
+          - mxe-i686-w64-mingw32.static-sdl2
+          - mxe-i686-w64-mingw32.static-sdl2-ttf
+      script:
+      - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,13 @@ matrix:
       - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS}
     # osx native build
     - os: osx
+      addons:
+        homebrew:
+          packages:
+          - sdl2
+          - sdl2_ttf
+          update: true
       env:
-      - MAKE_FLAGS="CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y V=s"
+      - MAKE_FLAGS="V=s"
       script:
       - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ matrix:
       env:
       - MAKE_FLAGS="V=s"
       script:
-      - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS}
+      - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS} test

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,9 @@ matrix:
           - mxe-i686-w64-mingw32.static-sdl2-ttf
       script:
       - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS}
+    # osx native build
+    - os: osx
+      env:
+      - MAKE_FLAGS="CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y V=s"
+      script:
+      - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,16 @@ env:
    - TESTRUN_WRAPPER='valgrind -q --error-exitcode=126 --track-origins=yes --leak-check=full' CFLAGS="-O1 -g3"
    - CFLAGS="-g3 -fsanitize=undefined -fsanitize=address -fsanitize=leak"
 script:
- - make clean && make -j$(nproc) test
+ - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS} -j$(nproc) test
 
 matrix:
   include:
     # test without sdl installed
     - os: linux
+      env:
+      - MAKE_FLAGS="CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y V=s"
       script:
-      - make CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y clean && make CONFIG_fft_eval_sdl=n CONFIG_fft_eval_json=y test
+      - make ${MAKE_FLAGS} clean && make ${MAKE_FLAGS} test
     # windows cross-compiler
     - os: linux
       env:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 ifeq ($(CONFIG_fft_eval_sdl),y)
   # test for presence of SDL
   ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
-    SDL2_CONFIG = sdl2-config
+    SDL2_CONFIG = $(CROSS)sdl2-config
     ifeq ($(shell which $(SDL2_CONFIG) 2>/dev/null),)
       $(error No SDL development libraries found!)
     endif
@@ -54,7 +54,7 @@ ifeq ($(CONFIG_fft_eval_sdl),y)
   LDLIBS_fft_eval_sdl += $(SDL_LDLIBS)
   
   ifeq ($(origin PKG_CONFIG), undefined)
-    PKG_CONFIG = pkg-config
+    PKG_CONFIG = $(CROSS)pkg-config
     ifeq ($(shell which $(PKG_CONFIG) 2>/dev/null),)
       $(error $(PKG_CONFIG) not found)
     endif
@@ -72,7 +72,7 @@ ifeq ($(CONFIG_fft_eval_sdl),y)
   LDLIBS_fft_eval_sdl += $(LIBSDL2TTF_LDLIBS)
 endif
 
-CC ?= cc
+CC = $(CROSS)gcc
 RM ?= rm -f
 INSTALL ?= install
 MKDIR ?= mkdir -p

--- a/fft_eval.c
+++ b/fft_eval.c
@@ -28,10 +28,21 @@
 
 #include "fft_eval.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
   #include <libkern/OSByteOrder.h>
   #define CONVERT_BE16(val)	val = OSSwapBigToHostInt16(val)
   #define CONVERT_BE64(val)	val = OSSwapBigToHostInt64(val)
+#elif defined(_WIN32)
+  #define __USE_MINGW_ANSI_STDIO 1
+  #if __BYTE_ORDER == __LITTLE_ENDIAN
+    #define CONVERT_BE16(val)	val = _byteswap_ushort(val)
+    #define CONVERT_BE64(val)	val = _byteswap_uint64(val)
+  #elif __BYTE_ORDER == __BIG_ENDIAN
+    #define CONVERT_BE16(val)
+    #define CONVERT_BE64(val)
+  #else
+    #error Endianess undefined
+  #endif
 #else
   #ifdef	__FreeBSD__
     #include <sys/endian.h>
@@ -65,7 +76,7 @@ static char *read_file(char *fname, size_t *size)
 	char *newbuf;
 	size_t ret;
 
-	fp = fopen(fname, "r");
+	fp = fopen(fname, "rb");
 
 	if (!fp)
 		return NULL;

--- a/fft_eval.h
+++ b/fft_eval.h
@@ -35,6 +35,10 @@ enum nl80211_channel_type {
 #define SPECTRAL_HT20_NUM_BINS          56
 #define SPECTRAL_HT20_40_NUM_BINS		128
 
+#if defined(__WIN32__)
+#pragma pack(push,1)
+#endif
+
 struct fft_sample_tlv {
         u8 type;        /* see ath_fft_sample */
         u16 length;
@@ -111,6 +115,10 @@ struct fft_sample_ath10k {
 
 	u8 data[0];
 } __attribute__((packed));
+
+#if defined(__WIN32__)
+#pragma pack(pop)
+#endif
 
 
 struct scanresult {

--- a/fft_eval_sdl.c
+++ b/fft_eval_sdl.c
@@ -26,19 +26,6 @@
  * based chipsets.
  */
 
-#ifdef __APPLE__
-  #include <libkern/OSByteOrder.h>
-  #define CONVERT_BE16(val)	val = OSSwapBigToHostInt16(val)
-  #define CONVERT_BE64(val)	val = OSSwapBigToHostInt64(val)
-#else
-  #ifdef	__FreeBSD__
-    #include <sys/endian.h>
-  #else
-    #include <endian.h>
-  #endif	/* __FreeBSD__ */
-  #define CONVERT_BE16(val)	val = be16toh(val)
-  #define CONVERT_BE64(val)	val = be64toh(val)
-#endif
 #include <errno.h>
 #include <stdio.h>
 #include <math.h>


### PR DESCRIPTION
The progams can be build and run under:

* FreeBSD
* Windows (with minor adjustments)
* Linux
* MacOS X

We can build binaries for most of these systems (beside FreeBSD) via Travis CI. And we can even run the tests on Linux and MacOS X via Travis CI. So also integrate both build and test script runs for non-Linux systems directly in the automated tests.