### PR TITLE
fft_eval: Add missing CONVERT_BE32 defines

### DIFF
--- a/fft_eval.c
+++ b/fft_eval.c
@@ -37,9 +37,11 @@
   #define __USE_MINGW_ANSI_STDIO 1
   #if __BYTE_ORDER == __LITTLE_ENDIAN
     #define CONVERT_BE16(val)	val = _byteswap_ushort(val)
+    #define CONVERT_BE32(val)	val = _byteswap_ulong(val)
     #define CONVERT_BE64(val)	val = _byteswap_uint64(val)
   #elif __BYTE_ORDER == __BIG_ENDIAN
     #define CONVERT_BE16(val)
+    #define CONVERT_BE32(val)
     #define CONVERT_BE64(val)
   #else
     #error Endianess undefined


### PR DESCRIPTION
Fixes: 68201c1ccd12 ("fft_eval: add support for ath11k")