### PR TITLE
fft_eval: Fix path to GPL-2.0-only license in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ and right). Scroll through the spectrum using the Page Up/Down keys.
 LICENSE
 =======
 
-Read the GPL v2 file 'COPYING'.
+Read the GPL v2 file 'LICENSES/GPL-2.0-only.txt'.
 
 AUTHOR
 ======


### PR DESCRIPTION
Fixes: 8e6ca0414bdc ("fft_eval: Implement FSFE REUSE 3.0 specification")